### PR TITLE
Use TimeSeriesDataPoint as a base for RawWeatherDatum

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -62,7 +62,7 @@ add_executable(tidal
         src/app/models/weather/RawWeatherDatum.cpp
         src/app/models/weather/RawWeatherDatum.h
         src/app/models/weather/RunLengthEncoding.cpp
-        src/app/models/weather/RunLengthEncoding.h)
+        src/app/models/weather/RunLengthEncoding.h src/app/models/utils/TimeSeries.cpp src/app/models/utils/TimeSeries.h)
 
 include_directories( ${Boost_INCLUDE_DIR} /usr/local/include /usr/local/Cellar/openssl@1.1/1.1.1g/include/)
 target_include_directories(tidal PUBLIC "${PROJECT_BINARY_DIR}" /usr/local/include/lunar /usr/local/include/graphLib)

--- a/src/app/TimeSeriesDataPoint.h
+++ b/src/app/TimeSeriesDataPoint.h
@@ -10,10 +10,11 @@
 
 class TimeSeriesDataPoint {
 private:
+    static inline bool comparator(TimeSeriesDataPoint l, TimeSeriesDataPoint r) { return l.getValue() < r.getValue(); };
+
+protected:
     tm timestamp{};
     double value;
-
-    static inline bool comparator(TimeSeriesDataPoint l, TimeSeriesDataPoint r) { return l.getValue() < r.getValue(); };
 
 public:
     TimeSeriesDataPoint();

--- a/src/app/models/utils/TimeSeries.cpp
+++ b/src/app/models/utils/TimeSeries.cpp
@@ -1,0 +1,6 @@
+//
+// Created by ciroque on 2021-10-31.
+//
+
+#include "TimeSeries.h"
+

--- a/src/app/models/utils/TimeSeries.h
+++ b/src/app/models/utils/TimeSeries.h
@@ -1,0 +1,37 @@
+//
+// Created by ciroque on 2021-10-31.
+//
+
+#ifndef TIDAL_TIMESERIES_H
+#define TIDAL_TIMESERIES_H
+
+#include <vector>
+#include "../../TimeSeriesDataPoint.h"
+
+class TimeSeries {
+public:
+
+    // NOTE: This definition must live in the header file, DO NOT MOVE IT TO THE SOURCE FILE.
+    // @see https://stackoverflow.com/questions/14005060/undefined-reference-to/14005118#14005118
+    //
+    //      You have defined your template in a separate .cpp file.
+    //      Each file is compiled separately.
+    //      Your create.cpp doesn't contain any running code so it is being discarded by the compiler.
+    //      Later, at a linkage stage, when the linker tries to link the binary of main.cpp with create_list,
+    //      it can't find it in other compiled objects thus you are getting this error.
+    //      To resolve it you need to instantiate your template at least once in your create.cpp
+    //      or have the implementation inside the header file.
+    template <typename T>
+    static std::vector<T> ValuesForHour(std::vector<T> vector, int hour) {
+        auto predicate = [&hour](const TimeSeriesDataPoint& timeSeriesDataPoint) {
+            return (timeSeriesDataPoint.getTimestamp().tm_hour == hour);
+        };
+
+        std::vector<T> found;
+        std::copy_if(vector.begin(), vector.end(), std::back_inserter(found), predicate);
+
+        return found;
+    }
+};
+
+#endif //TIDAL_TIMESERIES_H

--- a/src/app/models/weather/RawWeatherDatum.cpp
+++ b/src/app/models/weather/RawWeatherDatum.cpp
@@ -8,10 +8,8 @@
 
 std::regex ISO8601_DURATION_HOUR_EXTRACT = std::regex("^/?PT([0-9]+)H$");
 
-RawWeatherDatum::RawWeatherDatum(tm timestamp, int recurrence, double value) {
-    this->timestamp = timestamp;
+RawWeatherDatum::RawWeatherDatum(tm timestamp, int recurrence, double value) : TimeSeriesDataPoint(timestamp, value) {
     this->recurrence = recurrence;
-    this->value = value;
 }
 
 int RawWeatherDatum::Recurrence(const std::string& validTime) {

--- a/src/app/models/weather/RawWeatherDatum.h
+++ b/src/app/models/weather/RawWeatherDatum.h
@@ -8,16 +8,14 @@
 
 #include <regex>
 #include <string>
+#include "../../TimeSeriesDataPoint.h"
 
-class RawWeatherDatum {
+class RawWeatherDatum : public TimeSeriesDataPoint {
 private:
     static const char DURATION_DELIMITER = '/';
     static const std::regex FULL_TIMESTAMP_PARSER;
 
-    tm timestamp{};
     int recurrence;
-    double value;
-
 
     static int Recurrence(const std::string& timestamp);
     static tm AdjustTime(const std::string& validTime);

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -3,10 +3,14 @@
 add_executable(
         tests
         RawWeatherDatumTests.cpp
-        ../src/app/models/weather/RawWeatherDatum.cpp
         RunLengthEncodingTests.cpp
-        ../src/app/models/weather/RunLengthEncoding.cpp
-        ../src/app/TimeSeriesDataPoint.cpp
+        TimeSeriesTests.cpp
         ../src/app/Time.cpp
-        )
+        ../src/app/models/utils/TimeSeries.h
+        ../src/app/models/utils/TimeSeries.cpp
+        ../src/app/TimeSeriesDataPoint.cpp
+        ../src/app/models/weather/RawWeatherDatum.cpp
+        ../src/app/models/weather/RunLengthEncoding.cpp
+        ../src/app/models/weather/
+)
 target_link_libraries(tests PRIVATE Catch2::Catch2WithMain)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -5,5 +5,8 @@ add_executable(
         RawWeatherDatumTests.cpp
         ../src/app/models/weather/RawWeatherDatum.cpp
         RunLengthEncodingTests.cpp
-        ../src/app/models/weather/RunLengthEncoding.cpp)
+        ../src/app/models/weather/RunLengthEncoding.cpp
+        ../src/app/TimeSeriesDataPoint.cpp
+        ../src/app/Time.cpp
+        )
 target_link_libraries(tests PRIVATE Catch2::Catch2WithMain)

--- a/tests/TimeSeriesTests.cpp
+++ b/tests/TimeSeriesTests.cpp
@@ -1,0 +1,38 @@
+//
+// Created by ciroque on 2021-10-31.
+//
+#define CATCH_CONFIG_MAIN
+
+#include <catch2/catch_all.hpp>
+#include "../src/app/TimeSeriesDataPoint.h"
+#include "../src/app/models/utils/TimeSeries.h"
+#include "../src/app/models/weather/RawWeatherDatum.h"
+
+TEST_CASE("TimeSeries") {
+    SECTION("ValuesForHour") {
+        SECTION("With TimeSeriesDataPoints") {
+            auto timeSeriesData = std::vector<TimeSeriesDataPoint> {
+                    {tm{.tm_hour = 3}, 0.0},
+                    {tm{.tm_hour = 2}, 0.0},
+                    {tm{.tm_hour = 3}, 0.0},
+                    {tm{.tm_hour = 3}, 0.0},
+                    {tm{.tm_hour = 0}, 0.0}
+            };
+
+            REQUIRE(TimeSeries::ValuesForHour<TimeSeriesDataPoint>(timeSeriesData, 3).size() == 3);
+        }
+
+        SECTION("With RawWeatherData") {
+            auto rawWeatherData = std::vector<RawWeatherDatum> {
+                    {tm{.tm_hour = 3}, 1, 1.0},
+                    {tm{.tm_hour = 3}, 3, 2.0},
+                    {tm{.tm_hour = 2}, 1, 3.0},
+                    {tm{.tm_hour = 3}, 1, 4.0},
+                    {tm{.tm_hour = 5}, 1, 5.0}
+            };
+
+            REQUIRE(TimeSeries::ValuesForHour<RawWeatherDatum>(rawWeatherData, 3).size() == 3);
+            REQUIRE(TimeSeries::ValuesForHour<RawWeatherDatum>(rawWeatherData, 3).at(1).GetRecurrence() == 3);
+        }
+    }
+}


### PR DESCRIPTION
This allows the methods defined on TimeSeriesDataPoint lists to work on RawWeatherDatum instances