### PR TITLE
Pad missing leading values from weather data.

### DIFF
--- a/src/app/models/weather/WeatherParser.cpp
+++ b/src/app/models/weather/WeatherParser.cpp
@@ -18,8 +18,8 @@ std::map<std::string, std::vector<RawWeatherDatum>> WeatherParser::Parse(const s
     std::string timestamp;
     double value;
 
-    for(auto it = WeatherCommon::PredictionKeys.begin(); it != WeatherCommon::PredictionKeys.end(); ++it) {
-        auto listName = it->c_str();
+    for(const auto& predictionKey : WeatherCommon::PredictionKeys) {
+        auto listName = predictionKey.c_str();
         auto items = properties[listName]["values"];
 
         for(auto& item : items) {

--- a/src/app/models/weather/WeatherPredictions.cpp
+++ b/src/app/models/weather/WeatherPredictions.cpp
@@ -15,6 +15,7 @@ WeatherPredictions WeatherPredictions::Load() {
     auto data = retriever.Retrieve();
     auto rawPredictions = WeatherParser::Parse(data);
     UnrollEncoding(rawPredictions);
+    PadMissingValues();
 
     return *this;
 }
@@ -28,8 +29,8 @@ WeatherData WeatherPredictions::ForDate(const tm date) {
     auto windGusts = TimeSeries::ValuesForDate(this->predictions["windGusts"], date);
     auto skyCover = TimeSeries::ValuesForDate(this->predictions["skyCover"], date);
 
-    auto highTemperature = TimeSeries::ValuesForDate(this->predictions["maxTemperature"], date).front();
-    auto lowTemperature = TimeSeries::ValuesForDate(this->predictions["minTemperature"], date).front();
+    auto highTemperature = TimeSeries::ValuesForDate(this->predictions["temperature"], date).front();
+    auto lowTemperature = TimeSeries::ValuesForDate(this->predictions["temperature"], date).front();
     return {
         temperatures,
         apparentTemperatures,
@@ -47,5 +48,23 @@ void WeatherPredictions::UnrollEncoding(std::map<std::string, std::vector<RawWea
         auto unrolled = RunLengthEncoding::Decode(items);
         items.clear();
         this->predictions[listName] = unrolled;
+    }
+}
+
+// The use of std::vector::insert here is reasonably inefficient, but shouldn't be a problem. Sometime in the future
+// if someone is bored go ahead and fix it. Possibly just spin up a new vector and copy the values over...?
+void WeatherPredictions::PadMissingValues() {
+    for( const auto& listName : WeatherCommon::PredictionKeys) {
+        auto items = this->predictions[listName];
+        auto head = items.front();
+        auto missing = head.getTimestamp().tm_hour - 1;
+        for(missing; missing >= 0; missing--) {
+            auto padTimestamp = head.getTimestamp();
+            padTimestamp.tm_hour = missing;
+            TimeSeriesDataPoint pad = TimeSeriesDataPoint(padTimestamp, head.getValue());
+            items.insert(items.begin(), pad);
+        }
+        this->predictions[listName].clear();
+        this->predictions[listName] = items;
     }
 }

--- a/src/app/models/weather/WeatherPredictions.h
+++ b/src/app/models/weather/WeatherPredictions.h
@@ -17,6 +17,7 @@ private:
     std::map<std::string, std::vector<TimeSeriesDataPoint>> predictions;
 
     void UnrollEncoding(std::map<std::string, std::vector<RawWeatherDatum>> rawPredictions);
+    void PadMissingValues();
 
 public:
     explicit WeatherPredictions(const WeatherRetriever &retriever);


### PR DESCRIPTION
There might be a conflict with [PR 62](https://github.com/ciroque/tidal/pull/62) in `WeatherPredictions.cpp` where the `highTemperature`, and `lowTemperature` values are pulled from the JSON data. Moved to "temperature" instead of "minTemperature" and "maxTemperature". 

** This version should win the merge conflict.

Also:

- This change breaks getting more than 7 days, _think_ this is due to the weather api not returning data; not a big deal as showing more than 7 days is problematic on the display;
- There is a note about using `std::vector::insert` function. We are dealing with a relatively small number of elements, and no _real_ rush to process them. Maybe look into a performance improvement if it bugs someone, or out of boredom.