### PR TITLE
Fixing tests build

### DIFF
--- a/src/app/models/weather/RawWeatherDatum.cpp
+++ b/src/app/models/weather/RawWeatherDatum.cpp
@@ -3,10 +3,13 @@
 //
 
 #include "RawWeatherDatum.h"
+#include "../../Time.h"
 
 #include <string>
 
 std::regex ISO8601_DURATION_HOUR_EXTRACT = std::regex("^/?PT([0-9]+)H$");
+
+RawWeatherDatum::RawWeatherDatum() : TimeSeriesDataPoint(Time::GetLocalTime(), 0.0) { }
 
 RawWeatherDatum::RawWeatherDatum(tm timestamp, int recurrence, double value) : TimeSeriesDataPoint(timestamp, value) {
     this->recurrence = recurrence;
@@ -26,6 +29,8 @@ int RawWeatherDatum::DetermineRecurrence(const std::string& validTime) {
 
     return hours;
 }
+
+
 
 tm RawWeatherDatum::AdjustTime(const std::string& validTime){
     tm timestamp{.tm_isdst = -1};

--- a/src/app/models/weather/RawWeatherDatum.h
+++ b/src/app/models/weather/RawWeatherDatum.h
@@ -21,6 +21,7 @@ private:
     static tm AdjustTime(const std::string& validTime);
 
 public:
+    RawWeatherDatum();
     RawWeatherDatum(tm timestamp, int recurrence, double value);
 
     static RawWeatherDatum Build(const std::string& validTime, double value);


### PR DESCRIPTION
Using the value initializer ( T() )  requires a default constructor on the target. This adds that. 

See: src/app/models/utils/TimeSeries.h:55 / 60